### PR TITLE
Add living resume AI chat feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 # Varun Tyagi - Portfolio Website
 
 A modern, interactive portfolio website built with React, TypeScript, and Three.js.
+It now includes an experimental [Living Resume](docs/LivingResume.md) page powered by a conversational AI avatar.
 
 ## Overview
 
@@ -18,6 +19,7 @@ This portfolio website showcases my skills, projects, experience, and achievemen
 - **Experience Timeline**: Visual representation of professional experience
 - **Skills Section**: Overview of technical skills and expertise
 - **Achievements Display**: Showcase of certifications and notable accomplishments
+- **Living Resume**: Conversational AI avatar that answers questions about my experience
 
 ## Technologies Used
 

--- a/docs/LivingResume.md
+++ b/docs/LivingResume.md
@@ -1,0 +1,13 @@
+# Living Resume
+
+This portfolio includes an experimental "Living Resume" page that exposes a conversational AI avatar. You can access it at `/living-resume` once the project is running.
+
+## How It Works
+
+- **Chat Interface**: A simple React component maintains the conversation history and sends the user message to `/api/chat`.
+- **LLM Backend**: Implement the `/api/chat` endpoint using your preferred LLM provider (OpenAI, local model, etc.). The endpoint should accept the current chat history and return a JSON response with a `reply` field.
+- **Speech Synthesis**: Browser speech synthesis is triggered on each reply so the avatar can speak the response aloud.
+
+The AI avatar should be trained on your resume, project descriptions, and blog posts so it can respond in your voice and style. You can fine-tune a model or create embeddings for retrieval-augmented generation.
+
+This feature showcases skills in NLP, LLMs, and front‑end integration.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
+import LivingResume from "./pages/LivingResume";
 
 const queryClient = new QueryClient();
 
@@ -16,6 +17,7 @@ const App = () => (
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<Index />} />
+          <Route path="/living-resume" element={<LivingResume />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -25,6 +25,7 @@ const Navbar = () => {
     { name: 'Skills', href: '#skills' },
     { name: 'Achievements', href: '#achievements' },
     { name: 'Contact', href: '#contact' },
+    { name: 'AI Chat', href: '/living-resume' },
   ];
 
   // Social links with icons

--- a/src/components/ai/LivingResumeChat.tsx
+++ b/src/components/ai/LivingResumeChat.tsx
@@ -1,0 +1,88 @@
+import React, { useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+
+interface Message {
+  sender: 'user' | 'bot';
+  text: string;
+}
+
+const LivingResumeChat: React.FC = () => {
+  const [messages, setMessages] = useState<Message[]>([
+    { sender: 'bot', text: "Hi! I'm Varun's AI avatar. Ask me anything about his work." }
+  ]);
+  const [input, setInput] = useState('');
+  const [isSending, setIsSending] = useState(false);
+
+  const sendMessage = async () => {
+    const trimmed = input.trim();
+    if (!trimmed) return;
+    const userMsg = { sender: 'user', text: trimmed } as Message;
+    setMessages(prev => [...prev, userMsg]);
+    setInput('');
+    setIsSending(true);
+
+    try {
+      const res = await fetch('/api/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: trimmed, history: messages }),
+      });
+      const data = await res.json();
+      const reply = data.reply || 'Sorry, I had trouble answering that.';
+      if (typeof window !== 'undefined' && 'speechSynthesis' in window) {
+        window.speechSynthesis.speak(new SpeechSynthesisUtterance(reply));
+      }
+      setMessages(prev => [...prev, { sender: 'bot', text: reply }]);
+    } catch (err) {
+      setMessages(prev => [
+        ...prev,
+        { sender: 'bot', text: 'Oops! Something went wrong.' },
+      ]);
+    } finally {
+      setIsSending(false);
+    }
+  };
+
+  return (
+    <Card className="max-w-xl mx-auto my-12">
+      <CardHeader>
+        <CardTitle>Living Resume</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="h-64 overflow-y-auto space-y-3 mb-4">
+          {messages.map((m, idx) => (
+            <div key={idx} className={m.sender === 'user' ? 'text-right' : 'text-left'}>
+              <span
+                className={`inline-block px-3 py-2 rounded-lg ${
+                  m.sender === 'user' ? 'bg-neon-cyan/20' : 'bg-white/10'
+                }`}
+              >
+                {m.text}
+              </span>
+            </div>
+          ))}
+        </div>
+        <div className="flex gap-2">
+          <Input
+            placeholder="Ask about projects, skills, experience..."
+            value={input}
+            onChange={e => setInput(e.target.value)}
+            onKeyDown={e => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                sendMessage();
+              }
+            }}
+          />
+          <Button onClick={sendMessage} disabled={isSending}>
+            {isSending ? '...' : 'Send'}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default LivingResumeChat;

--- a/src/pages/LivingResume.tsx
+++ b/src/pages/LivingResume.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import Navbar from '@/components/Navbar';
+import Footer from '@/components/Footer';
+import LivingResumeChat from '@/components/ai/LivingResumeChat';
+
+const LivingResume: React.FC = () => (
+  <div className="min-h-screen bg-dark text-white overflow-x-hidden">
+    <Navbar />
+    <LivingResumeChat />
+    <Footer />
+  </div>
+);
+
+export default LivingResume;


### PR DESCRIPTION
## Summary
- add experimental Living Resume chat page and components
- update navbar routing and app routes
- document AI avatar usage in README and docs

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6841f09c9e9c83259b27ce28b413082c