### PR TITLE
Add local Llama backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,14 @@ npm install --legacy-peer-deps
 npm run dev
 ```
 
-4. Open [http://localhost:8080](http://localhost:8080) to view it in the browser
+4. In another terminal, start the chat API which proxies to your local Llama model
+```sh
+npm run server
+```
+
+Make sure the Ollama server is running and serving a model such as `llama3.2:latest`.
+
+5. Open [http://localhost:8080](http://localhost:8080) to view it in the browser
 
 ### Building for Production
 

--- a/docs/LivingResume.md
+++ b/docs/LivingResume.md
@@ -11,3 +11,30 @@ This portfolio includes an experimental "Living Resume" page that exposes a conv
 The AI avatar should be trained on your resume, project descriptions, and blog posts so it can respond in your voice and style. You can fine-tune a model or create embeddings for retrieval-augmented generation.
 
 This feature showcases skills in NLP, LLMs, and front‑end integration.
+
+## Local Llama Setup
+
+The repository now includes a small Express server that proxies requests to a local Llama model served by [Ollama](https://ollama.ai/).
+
+1. Start the Ollama server and pull the desired model, for example:
+
+   ```sh
+   ollama serve &
+   ollama pull llama3.2:latest
+   ```
+
+2. In a separate terminal, run the chat server:
+
+   ```sh
+   npm run server
+   ```
+
+   This starts an API on `http://localhost:3001/api/chat`.
+
+3. Finally, start the Vite dev server:
+
+   ```sh
+   npm run dev
+   ```
+
+Navigate to `http://localhost:8080/living-resume` to chat with your AI avatar powered by the local model.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "server": "node server/index.js"
   },
   "dependencies": {
     "@emailjs/browser": "^4.4.1",
@@ -45,6 +46,8 @@
     "@react-three/fiber": "^8.18.0",
     "@react-three/postprocessing": "^3.0.4",
     "@tanstack/react-query": "^5.56.2",
+    "axios": "^1.6.8",
+    "express": "^4.19.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.0.0",

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,29 @@
+import express from 'express';
+import axios from 'axios';
+
+const app = express();
+app.use(express.json());
+
+const MODEL = process.env.LLAMA_MODEL || 'llama3.2:latest';
+const OLLAMA_URL = process.env.OLLAMA_URL || 'http://localhost:11434/api/generate';
+
+app.post('/api/chat', async (req, res) => {
+  const { message } = req.body;
+  if (!message) {
+    return res.status(400).json({ reply: 'No message provided' });
+  }
+  try {
+    const resp = await axios.post(OLLAMA_URL, {
+      model: MODEL,
+      prompt: message,
+      stream: false,
+    });
+    res.json({ reply: resp.data.response.trim() });
+  } catch (err) {
+    console.error('LLM error:', err.message);
+    res.status(500).json({ reply: 'Oops! Something went wrong.' });
+  }
+});
+
+const port = process.env.PORT || 3001;
+app.listen(port, () => console.log(`Chat server listening on ${port}`));

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,9 @@ export default defineConfig(({ mode }) => ({
   server: {
     host: "::",
     port: 8080,
+    proxy: {
+      "/api": "http://localhost:3001",
+    },
   },
   plugins: [
     react(),


### PR DESCRIPTION
## Summary
- hook up `/api/chat` endpoint via a small Express server
- proxy API requests from Vite dev server
- document how to run the local Llama setup

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6841fd5d99ec83258b4df55728f89dad