### PR TITLE
Improve local Llama setup steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,25 @@ cd portfolio
 npm install --legacy-peer-deps
 ```
 
-3. Start the development server
+3. In one terminal, start the Ollama server **(do not use `ollama run`)** so that it exposes
+   the HTTP API used by the chat backend:
+```sh
+ollama serve
+```
+
+4. In **another terminal**, pull a model (if you haven't already) and run the chat API
+   which proxies to your local Llama model:
+```sh
+ollama pull llama3.2:latest
+npm run server
+```
+
+5. Finally, start the Vite dev server
 ```sh
 npm run dev
 ```
 
-4. Open [http://localhost:8080](http://localhost:8080) to view it in the browser
+Open [http://localhost:8080](http://localhost:8080) to view it in the browser.
 
 ### Building for Production
 
@@ -85,6 +98,14 @@ This site is configured for deployment on Vercel. When deploying, make sure to:
 
 1. Add the environment variable `NPM_FLAGS` with the value `--legacy-peer-deps` in your Vercel project settings
 2. Connect your repository to Vercel for automatic deployments
+
+## Troubleshooting
+
+If you see an `ECONNREFUSED` error when chatting with the avatar, ensure that:
+
+1. The Ollama server is running (`ollama serve`).
+2. You have started the API server with `npm run server`.
+3. You can verify the Llama API is reachable with `curl http://localhost:11434/api/generate`.
 
 ## Contact
 

--- a/docs/LivingResume.md
+++ b/docs/LivingResume.md
@@ -11,3 +11,35 @@ This portfolio includes an experimental "Living Resume" page that exposes a conv
 The AI avatar should be trained on your resume, project descriptions, and blog posts so it can respond in your voice and style. You can fine-tune a model or create embeddings for retrieval-augmented generation.
 
 This feature showcases skills in NLP, LLMs, and front‑end integration.
+
+## Local Llama Setup
+
+The repository now includes a small Express server that proxies requests to a local Llama model served by [Ollama](https://ollama.ai/).
+
+1. In one terminal, start the Ollama server (again, **use `ollama serve`, not `ollama run`**):
+
+   ```sh
+   ollama serve
+   ```
+
+2. In another terminal, pull the desired model (if needed) and run the chat server:
+
+   ```sh
+   ollama pull llama3.2:latest
+   npm run server
+   ```
+
+   This starts an API on `http://localhost:3001/api/chat`.
+
+3. Finally, start the Vite dev server:
+
+   ```sh
+   npm run dev
+   ```
+
+Navigate to `http://localhost:8080/living-resume` to chat with your AI avatar powered by the local model.
+
+If you see connection errors, confirm the Ollama API is reachable:
+```sh
+curl http://localhost:11434/api/generate
+```

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "server": "node server/index.js"
   },
   "dependencies": {
     "@emailjs/browser": "^4.4.1",
@@ -45,6 +46,7 @@
     "@react-three/fiber": "^8.18.0",
     "@react-three/postprocessing": "^3.0.4",
     "@tanstack/react-query": "^5.56.2",
+    "express": "^4.19.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.0.0",

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,34 @@
+import express from 'express';
+
+const app = express();
+app.use(express.json());
+
+const MODEL = process.env.LLAMA_MODEL || 'llama3.2:latest';
+const OLLAMA_URL = process.env.OLLAMA_URL || 'http://localhost:11434/api/generate';
+
+app.post('/api/chat', async (req, res) => {
+  const { message } = req.body;
+  if (!message) {
+    return res.status(400).json({ reply: 'No message provided' });
+  }
+  try {
+    const resp = await fetch(OLLAMA_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: MODEL,
+        prompt: message,
+        stream: false,
+      }),
+    });
+    const data = await resp.json();
+    res.json({ reply: data.response.trim() });
+  } catch (err) {
+    console.error('LLM error:', err.message);
+    console.error('Is the Ollama server running on', OLLAMA_URL, '?');
+    res.status(500).json({ reply: 'Oops! Something went wrong.' });
+  }
+});
+
+const port = process.env.PORT || 3001;
+app.listen(port, () => console.log(`Chat server listening on ${port}`));

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,9 @@ export default defineConfig(({ mode }) => ({
   server: {
     host: "::",
     port: 8080,
+    proxy: {
+      "/api": "http://localhost:3001",
+    },
   },
   plugins: [
     react(),


### PR DESCRIPTION
## Summary
- clarify that `ollama serve` should be run in its own terminal
- instruct pulling the model and running the chat server from another terminal

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_6841fd5d99ec83258b4df55728f89dad