### PR TITLE
Improve local Llama setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,33 @@ cd portfolio
 npm install --legacy-peer-deps
 ```
 
-3. Start the development server
+3. In **one terminal**, start the Ollama server so that it exposes the HTTP API used by the chat backend. Be sure to use `ollama serve` (not `ollama run`):
+```sh
+ollama serve
+```
+
+4. In a **second terminal**, pull the model (only needed the first time) and then run the chat API which proxies to your local Llama model. Leave this terminal running:
+```sh
+ollama pull llama3.2:latest
+npm run server
+```
+
+   The server should log `Chat server listening on 3001`. Keep this terminal running so the frontend can talk to it.
+
+   Verify the API is responding:
+   ```sh
+   curl -X POST http://localhost:3001/api/chat \
+     -H 'Content-Type: application/json' \
+     -d '{"message":"ping"}'
+   ```
+Make sure the Ollama server is running and serving a model such as `llama3.2:latest`.
+
+5. Start the Vite dev server
 ```sh
 npm run dev
 ```
 
-4. Open [http://localhost:8080](http://localhost:8080) to view it in the browser
+6. Open [http://localhost:8080](http://localhost:8080) to view it in the browser.
 
 ### Building for Production
 
@@ -85,6 +106,15 @@ This site is configured for deployment on Vercel. When deploying, make sure to:
 
 1. Add the environment variable `NPM_FLAGS` with the value `--legacy-peer-deps` in your Vercel project settings
 2. Connect your repository to Vercel for automatic deployments
+
+## Troubleshooting
+
+If you see an `ECONNREFUSED` error when chatting with the avatar, ensure that:
+
+1. The Ollama server is running (`ollama serve`).
+2. You have started the API server with `npm run server`.
+3. You can verify the Llama API is reachable with `curl http://localhost:11434/api/generate`.
+4. Test the chat endpoint itself: `curl -X POST http://localhost:3001/api/chat -H 'Content-Type: application/json' -d '{"message":"ping"}'`.
 
 ## Contact
 

--- a/docs/LivingResume.md
+++ b/docs/LivingResume.md
@@ -11,3 +11,54 @@ This portfolio includes an experimental "Living Resume" page that exposes a conv
 The AI avatar should be trained on your resume, project descriptions, and blog posts so it can respond in your voice and style. You can fine-tune a model or create embeddings for retrieval-augmented generation.
 
 This feature showcases skills in NLP, LLMs, and front‑end integration.
+
+## Local Llama Setup
+
+The repository now includes a small Express server that proxies requests to a local Llama model served by [Ollama](https://ollama.ai/).
+
+1. In one terminal, start the Ollama server (again, **use `ollama serve`, not `ollama run`**):
+
+   ```sh
+   ollama serve
+   ```
+
+2. In a **second terminal**, pull the desired model (only needed the first time) and start the chat server. Leave this terminal running so the front end can reach it:
+
+   ```sh
+   ollama pull llama3.2:latest
+   npm run server
+
+   The server should print `Chat server listening on 3001` when it starts.
+   ```
+
+   This starts an API on `http://localhost:3001/api/chat`.
+
+   You can test it with:
+
+   ```sh
+   curl -X POST http://localhost:3001/api/chat \
+     -H 'Content-Type: application/json' \
+     -d '{"message":"ping"}'
+   ```
+
+3. Finally, start the Vite dev server:
+
+   ```sh
+   npm run dev
+   ```
+
+Navigate to `http://localhost:8080/living-resume` to chat with your AI avatar powered by the local model.
+
+If you see connection errors, confirm the Ollama API is reachable:
+```sh
+curl http://localhost:11434/api/generate
+```
+You can also test the chat server directly:
+```sh
+curl -X POST http://localhost:3001/api/chat \
+  -H 'Content-Type: application/json' \
+  -d '{"message":"ping"}'
+```
+
+If the chat interface reports an `ECONNREFUSED` error, double-check that both
+`ollama serve` and `npm run server` are running in their own terminals.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "server": "node server/index.js"
   },
   "dependencies": {
     "@emailjs/browser": "^4.4.1",
@@ -45,6 +46,8 @@
     "@react-three/fiber": "^8.18.0",
     "@react-three/postprocessing": "^3.0.4",
     "@tanstack/react-query": "^5.56.2",
+    "axios": "^1.6.8",
+    "express": "^4.19.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.0.0",

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,48 @@
+import express from 'express';
+import axios from 'axios';
+import fs from 'node:fs';
+
+const projects = JSON.parse(fs.readFileSync(new URL('./projects.json', import.meta.url)));
+
+const app = express();
+app.use(express.json());
+
+const MODEL = process.env.LLAMA_MODEL || 'llama3.2:latest';
+const OLLAMA_URL = process.env.OLLAMA_URL || 'http://localhost:11434/api/generate';
+
+console.log('\u25B6\uFE0E Using MODEL =', MODEL);
+console.log('\u25B6\uFE0E Using OLLAMA_URL =', `'${OLLAMA_URL}'`);
+
+app.post('/api/chat', async (req, res) => {
+  const { message } = req.body;
+  console.log('• Received POST /api/chat with body:', req.body);
+
+  if (!message) {
+    return res.status(400).json({ reply: 'No message provided' });
+  }
+  try {
+    const lower = message.toLowerCase();
+    if (lower.includes('project')) {
+      const list = projects.map((p) => p.title).join(', ');
+      return res.json({ reply: `Here are some of my projects: ${list}.` });
+    }
+
+    console.log(`→ Forwarding to Ollama at: ${OLLAMA_URL}`);
+    console.log('  Payload =', { model: MODEL, prompt: message, stream: false });
+
+    const resp = await axios.post(OLLAMA_URL, {
+      model: MODEL,
+      prompt: message,
+      stream: false,
+    });
+
+    console.log('← Ollama replied:', resp.data);
+    res.json({ reply: resp.data.response.trim() });
+  } catch (err) {
+    console.error('LLM error (full error object):', err);
+    res.status(500).json({ reply: 'Oops! Something went wrong.' });
+  }
+});
+
+const port = process.env.PORT || 3001;
+app.listen(port, () => console.log(`Chat server listening on ${port}`));

--- a/server/projects.json
+++ b/server/projects.json
@@ -1,0 +1,47 @@
+[
+  {
+    "id": 1,
+    "title": "VitalCarePlatform",
+    "description": "A healthcare SaaS platform connecting users to AI-powered medical services through subscriptions.",
+    "technologies": ["React", "Next.js", "PostgreSQL", "JWT", "REST API", "Tailwind CSS"],
+    "image": "https://placehold.co/600x400/1A1F2C/FFFFFF?text=VitalCarePlatform",
+    "githubUrl": "https://github.com/",
+    "demoUrl": "https://nextjs-login-sooty.vercel.app/"
+  },
+  {
+    "id": 2,
+    "title": "QuickCart E-commerce App",
+    "description": "A modern e-commerce platform with authentication, payment processing, and order management.",
+    "technologies": ["Next.js", "Clerk", "MongoDB", "Inngest", "Tailwind CSS"],
+    "image": "https://placehold.co/600x400/1A1F2C/FFFFFF?text=QuickCart+App",
+    "githubUrl": "https://github.com/",
+    "demoUrl": "https://littlewisewesbite-ten.vercel.app/"
+  },
+  {
+    "id": 3,
+    "title": "PDF-based RAG Application",
+    "description": "An intelligent document Q&A system using retrieval augmented generation techniques.",
+    "technologies": ["LangChain", "Streamlit", "FAISS", "Ollama", "Python"],
+    "image": "https://placehold.co/600x400/1A1F2C/FFFFFF?text=PDF+RAG+App",
+    "githubUrl": "https://github.com/",
+    "demoUrl": "https://drive.google.com/drive/folders/1rW2ufZNwpmeH1E4dX-JW1qkERoM-fH3P?usp=sharing"
+  },
+  {
+    "id": 4,
+    "title": "OCR & Text Analysis Tool",
+    "description": "Computer vision application that extracts and analyzes text from images and documents.",
+    "technologies": ["Google Vision API", "OpenCV", "HuggingFace", "Flask", "React"],
+    "image": "https://placehold.co/600x400/1A1F2C/FFFFFF?text=OCR+Analysis+Tool",
+    "githubUrl": "https://github.com/",
+    "demoUrl": "https://drive.google.com/file/d/1Qw308EiVN0OMuQ0q1vvTgAgCuIXhLctP/view?usp=sharing"
+  },
+  {
+    "id": 5,
+    "title": "Jobify - Job Seeking App",
+    "description": "A comprehensive platform for job seekers to find and apply for opportunities.",
+    "technologies": ["React", "MongoDB", "Express", "Node.js", "Tailwind CSS"],
+    "image": "https://placehold.co/600x400/1A1F2C/FFFFFF?text=Jobify",
+    "githubUrl": "https://github.com/",
+    "demoUrl": "https://jobify-j55w.onrender.com/dashboard/profile"
+  }
+]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,9 @@ export default defineConfig(({ mode }) => ({
   server: {
     host: "::",
     port: 8080,
+    proxy: {
+      "/api": "http://localhost:3001",
+    },
   },
   plugins: [
     react(),


### PR DESCRIPTION
## Summary
- document steps for keeping Ollama and the API server running
- add troubleshooting notes for `ECONNREFUSED`
- implement local chat backend using Express and built-in `fetch`
- teach chat server about portfolio projects
- switch chat server to axios with detailed logging

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6841fd5d99ec83258b4df55728f89dad