### PR TITLE
Add conversation memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ This portfolio website showcases my skills, projects, experience, and achievemen
 - **Skills Section**: Overview of technical skills and expertise
 - **Achievements Display**: Showcase of certifications and notable accomplishments
 - **Living Resume**: Conversational AI avatar that answers questions about my experience
+- **Project List via Chat**: Ask the avatar for my portfolio projects and it will list them
+- **Experience & Education via Chat**: Ask about my background and the avatar shares a quick summary
+- **Personal Bio via Chat**: Ask "Who is Varun?" and the avatar responds with a short introduction
+- **Voice Controls**: Pause, resume, or stop the avatar's speech while chatting
+- **Conversational Memory**: The server remembers recent chat history for each browser session so the avatar keeps context even after a page reload
 
 ## Technologies Used
 
@@ -49,13 +54,36 @@ cd portfolio
 ```sh
 npm install --legacy-peer-deps
 ```
+   If you update the repository later and new dependencies were added,
+   run `npm install` again so the server has everything it needs.
 
-3. Start the development server
+3. In **one terminal**, start the Ollama server so that it exposes the HTTP API used by the chat backend. Be sure to use `ollama serve` (not `ollama run`):
+```sh
+ollama serve
+```
+
+4. In a **second terminal**, pull the model (only needed the first time) and then run the chat API which proxies to your local Llama model. Leave this terminal running:
+```sh
+ollama pull llama3.2:latest
+npm run server
+```
+
+   The server should log `Chat server listening on 3001`. Keep this terminal running so the frontend can talk to it.
+
+   Verify the API is responding:
+   ```sh
+   curl -X POST http://localhost:3001/api/chat \
+     -H 'Content-Type: application/json' \
+     -d '{"message":"ping"}'
+   ```
+Make sure the Ollama server is running and serving a model such as `llama3.2:latest`.
+
+5. Start the Vite dev server
 ```sh
 npm run dev
 ```
 
-4. Open [http://localhost:8080](http://localhost:8080) to view it in the browser
+6. Open [http://localhost:8080](http://localhost:8080) to view it in the browser.
 
 ### Building for Production
 
@@ -85,6 +113,15 @@ This site is configured for deployment on Vercel. When deploying, make sure to:
 
 1. Add the environment variable `NPM_FLAGS` with the value `--legacy-peer-deps` in your Vercel project settings
 2. Connect your repository to Vercel for automatic deployments
+
+## Troubleshooting
+
+If you see an `ECONNREFUSED` error when chatting with the avatar, ensure that:
+
+1. The Ollama server is running (`ollama serve`).
+2. You have started the API server with `npm run server`.
+3. You can verify the Llama API is reachable with `curl http://localhost:11434/api/generate`.
+4. Test the chat endpoint itself: `curl -X POST http://localhost:3001/api/chat -H 'Content-Type: application/json' -d '{"message":"ping"}'`.
 
 ## Contact
 

--- a/docs/LivingResume.md
+++ b/docs/LivingResume.md
@@ -7,7 +7,69 @@ This portfolio includes an experimental "Living Resume" page that exposes a conv
 - **Chat Interface**: A simple React component maintains the conversation history and sends the user message to `/api/chat`.
 - **LLM Backend**: Implement the `/api/chat` endpoint using your preferred LLM provider (OpenAI, local model, etc.). The endpoint should accept the current chat history and return a JSON response with a `reply` field.
 - **Speech Synthesis**: Browser speech synthesis is triggered on each reply so the avatar can speak the response aloud.
+- **Conversation Memory**: The backend remembers recent history for each session so it can respond with context even after you refresh the page. The browser stores a session ID in `localStorage` to keep the conversation tied to you.
 
 The AI avatar should be trained on your resume, project descriptions, and blog posts so it can respond in your voice and style. You can fine-tune a model or create embeddings for retrieval-augmented generation.
 
 This feature showcases skills in NLP, LLMs, and front‑end integration.
+
+The backend also knows about the portfolio projects listed in `server/projects.json`. If the user asks about "projects" in chat, the server will respond with a short list instead of forwarding the question to the LLM.
+It can also summarize my work experience and education from `server/profile.json`.
+It will even introduce me if you ask "Who is Varun?" using the brief bio stored in that file.
+
+### Voice Controls
+
+Speech output supports pause/resume. Use the buttons below the chat input to pause or resume the spoken reply. Sending a new message automatically stops any previous speech.
+
+## Local Llama Setup
+
+The repository now includes a small Express server that proxies requests to a local Llama model served by [Ollama](https://ollama.ai/).
+
+1. In one terminal, start the Ollama server (again, **use `ollama serve`, not `ollama run`**):
+
+   ```sh
+   ollama serve
+   ```
+
+2. In a **second terminal**, pull the desired model (only needed the first time) and start the chat server. Leave this terminal running so the front end can reach it:
+
+   ```sh
+   ollama pull llama3.2:latest
+   # install dependencies if you haven't already
+   npm install --legacy-peer-deps
+   npm run server
+
+   The server should print `Chat server listening on 3001` when it starts.
+   ```
+
+   This starts an API on `http://localhost:3001/api/chat`.
+
+   You can test it with:
+
+   ```sh
+   curl -X POST http://localhost:3001/api/chat \
+     -H 'Content-Type: application/json' \
+     -d '{"message":"ping"}'
+   ```
+
+3. Finally, start the Vite dev server:
+
+   ```sh
+   npm run dev
+   ```
+
+Navigate to `http://localhost:8080/living-resume` to chat with your AI avatar powered by the local model.
+
+If you see connection errors, confirm the Ollama API is reachable:
+```sh
+curl http://localhost:11434/api/generate
+```
+You can also test the chat server directly:
+```sh
+curl -X POST http://localhost:3001/api/chat \
+  -H 'Content-Type: application/json' \
+  -d '{"message":"ping"}'
+```
+
+If the chat interface reports an `ECONNREFUSED` error, double-check that both
+`ollama serve` and `npm run server` are running in their own terminals.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "server": "node server/index.js"
   },
   "dependencies": {
     "@emailjs/browser": "^4.4.1",
@@ -45,6 +46,8 @@
     "@react-three/fiber": "^8.18.0",
     "@react-three/postprocessing": "^3.0.4",
     "@tanstack/react-query": "^5.56.2",
+    "axios": "^1.6.8",
+    "express": "^4.19.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.0.0",

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,139 @@
+import express from 'express';
+import axios from 'axios';
+import fs from 'node:fs';
+
+const projects = JSON.parse(fs.readFileSync(new URL('./projects.json', import.meta.url)));
+const profile = JSON.parse(fs.readFileSync(new URL('./profile.json', import.meta.url)));
+
+const app = express();
+app.use(express.json());
+
+// Keep chat state (history, tone, language) in memory for each session ID
+const sessions = new Map();
+
+const MODEL = process.env.LLAMA_MODEL || 'llama3.2:latest';
+const OLLAMA_URL = process.env.OLLAMA_URL || 'http://localhost:11434/api/generate';
+
+console.log('\u25B6\uFE0E Using MODEL =', MODEL);
+console.log('\u25B6\uFE0E Using OLLAMA_URL =', `'${OLLAMA_URL}'`);
+
+app.post('/api/chat', async (req, res) => {
+  const { message, sessionId = 'default' } = req.body;
+  const state = sessions.get(sessionId) || { history: [], tone: 'neutral', language: 'en' };
+  const { history, tone, language } = state;
+  console.log('• Received POST /api/chat with body:', req.body);
+
+  if (!message) {
+    return res.status(400).json({ reply: 'No message provided' });
+  }
+  try {
+    const lower = message.toLowerCase();
+    const projectKeywords = /\bprojects?\b|portfolio/;
+    const projectDetailRegex = /(read|show|tell).*\b(details?)\b.*(\b[A-Za-z0-9- ]+)/;
+    const experienceKeywords = /\bexperience\b|work history|background/;
+    const educationKeywords = /\beducation\b|degree|studies/;
+    const skillsKeywords = /\bskills?\b|tech stack/;
+    const achievementKeywords = /\bachievements?\b|accomplishments?/;
+    const bioKeywords = /who\s+is\s+varun|who\s+are\s+you|tell me about (?:yourself|varun)/;
+    const toneRegex = /set tone to (casual|formal)/;
+    const langRegex = /speak in (\w+)/;
+
+    if (toneRegex.test(lower)) {
+      const [, t] = lower.match(toneRegex)!;
+      state.tone = t;
+      sessions.set(sessionId, state);
+      return res.json({ reply: `Okay, I'll respond in a ${t} tone from now on.` });
+    }
+
+    if (langRegex.test(lower)) {
+      const [, lang] = lower.match(langRegex)!;
+      state.language = lang.toLowerCase();
+      sessions.set(sessionId, state);
+      return res.json({ reply: `Got it. I'll reply in ${lang} when possible.` });
+    }
+
+    if (projectDetailRegex.test(lower)) {
+      const match = lower.match(projectDetailRegex);
+      const name = match ? match[3].trim() : '';
+      const proj = projects.find(p => p.title.toLowerCase().includes(name));
+      if (proj) {
+        return res.json({ reply: `${proj.title}: ${proj.description}` });
+      }
+    }
+
+    if (projectKeywords.test(lower)) {
+      const list = projects.map((p) => p.title).join(', ');
+      return res.json({ reply: `Here are some of my projects: ${list}.` });
+    }
+
+    if (bioKeywords.test(lower)) {
+      return res.json({ reply: profile.bio });
+    }
+
+    if (experienceKeywords.test(lower)) {
+      const summary = profile.experience
+        .map((e) => `${e.position} at ${e.company} (${e.period})`)
+        .join('; ');
+      return res.json({ reply: `Here's a summary of my experience: ${summary}.` });
+    }
+
+    if (educationKeywords.test(lower)) {
+      const summary = profile.education
+        .map((e) => `${e.degree} from ${e.school} (${e.period})`)
+        .join('; ');
+      return res.json({ reply: `Here's my education: ${summary}.` });
+    }
+
+    if (skillsKeywords.test(lower)) {
+      const list = [
+        ...profile.skills.languages,
+        ...profile.skills.frameworks,
+        ...profile.skills.ml
+      ].join(', ');
+      return res.json({ reply: `Here are some of my key skills: ${list}.` });
+    }
+
+    if (achievementKeywords.test(lower)) {
+      const list = profile.achievements.join('; ');
+      return res.json({ reply: `Here are some of my achievements: ${list}.` });
+    }
+
+    // Build a conversation prompt using the previous messages and tone/language hints.
+    const contextLines = history
+      .slice(-10)
+      .map((m) => `${m.sender === 'user' ? 'User' : 'Assistant'}: ${m.text}`)
+      .join('\n');
+    const prompt = `${contextLines}\nUser: ${message}\nAssistant:`.trim();
+    const system = `Respond in a ${tone} style. Use ${language} language.`;
+    const finalPrompt = `${system}\n${prompt}`;
+
+    console.log(`→ Forwarding to Ollama at: ${OLLAMA_URL}`);
+    console.log('  Payload =', { model: MODEL, prompt: finalPrompt, stream: false });
+
+    const resp = await axios.post(OLLAMA_URL, {
+      model: MODEL,
+      prompt: finalPrompt,
+      stream: false,
+    });
+
+    let reply = resp.data.response.trim();
+    if (!reply) {
+      reply = 'I\'m not sure I understood that. Could you rephrase?';
+    }
+    console.log('← Ollama replied:', resp.data);
+
+    // save conversation history for this session
+    history.push({ sender: 'user', text: message });
+    history.push({ sender: 'bot', text: reply });
+    sessions.set(sessionId, { history, tone: state.tone, language: state.language });
+
+    res.json({ reply });
+  } catch (err) {
+    console.error('LLM error (full error object):', err);
+    console.error('Is the Ollama server running on', OLLAMA_URL, '?');
+    res.status(500).json({ reply: 'Oops! Something went wrong.' });
+  }
+});
+
+const port = process.env.PORT || 3001;
+app.listen(port, () => console.log(`Chat server listening on ${port}`));

--- a/server/profile.json
+++ b/server/profile.json
@@ -1,0 +1,64 @@
+{
+  "bio": "I'm Varun Tyagi, a full‑stack developer and machine learning engineer passionate about shipping real‑world products using modern web technologies and AI.",
+  "experience": [
+    {
+      "company": "Eigengram",
+      "position": "Software Engineer Intern",
+      "period": "Nov 2024 – Apr 2025",
+      "highlights": [
+        "Built image classification pipelines with VGG, ResNet and EfficientNet",
+        "Created automated data scraping and processing pipelines for ML tasks",
+        "Deployed scalable AWS infrastructure (EC2 + S3)",
+        "Implemented a latent diffusion based text‑to‑image model"
+      ]
+    },
+    {
+      "company": "Rovisor Research",
+      "position": "Software Development Intern",
+      "period": "Jun 2024 – Aug 2024",
+      "highlights": [
+        "Enhanced frontend UX with Angular and integrated new APIs",
+        "Optimized load times by 20%",
+        "Collaborated closely with the UX team on user flows"
+      ]
+    },
+    {
+      "company": "Business Web Solutions",
+      "position": "Web Developer Intern",
+      "period": "May 2024 – Jun 2024",
+      "highlights": [
+        "Designed responsive interfaces with HTML/CSS/JS",
+        "Optimized web assets and performance",
+        "Created cross‑browser compatible solutions"
+      ]
+    }
+  ],
+  "education": [
+    {
+      "school": "Netaji Subhas University of Technology (NSUT), New Delhi",
+      "degree": "B.Tech in Electronics and Technology (IoT)",
+      "period": "2020 – 2024"
+    }
+  ],
+  "skills": {
+    "languages": ["Python", "JavaScript", "TypeScript", "C++", "C", "SQL", "Node.js"],
+    "frameworks": ["Next.js", "React", "Express.js", "Tailwind CSS", "Streamlit", "Docker"],
+    "ml": ["LangChain", "Hugging Face Transformers", "FAISS", "scikit-learn", "PyTorch", "OpenCV"],
+    "cloud": ["AWS", "Google Cloud Vision", "Document AI", "Boto3", "Supabase", "Vercel"],
+    "databases": ["MongoDB", "PostgreSQL", "MySQL"]
+  },
+  "achievements": [
+    "Solved 320+ questions on GeeksforGeeks and 250+ on LeetCode",
+    "CodeChef rating of 1500",
+    "Scored 98.2 percentile in JEE Mains",
+    "Built and deployed multiple production ready AI-powered tools"
+  ],
+  "links": {
+    "portfolio": "https://portfolios-lovat.vercel.app/",
+    "github": "https://github.com/Varuno8",
+    "resume": "https://drive.google.com/file/d/1zVTN-6JsKmaaIU5qM1okq3pL0qSDCi4N/view",
+    "linkedin": "https://www.linkedin.com/in/varun-tyagi-32bb281b9/",
+    "email": "varun28082001@gmail.com",
+    "phone": "+91 7011793823"
+  }
+}

--- a/server/projects.json
+++ b/server/projects.json
@@ -1,0 +1,47 @@
+[
+  {
+    "id": 1,
+    "title": "VitalCarePlatform",
+    "description": "A healthcare SaaS platform connecting users to AI-powered medical services through subscriptions.",
+    "technologies": ["React", "Next.js", "PostgreSQL", "JWT", "REST API", "Tailwind CSS"],
+    "image": "https://placehold.co/600x400/1A1F2C/FFFFFF?text=VitalCarePlatform",
+    "githubUrl": "https://github.com/",
+    "demoUrl": "https://nextjs-login-sooty.vercel.app/"
+  },
+  {
+    "id": 2,
+    "title": "QuickCart E-commerce App",
+    "description": "A modern e-commerce platform with authentication, payment processing, and order management.",
+    "technologies": ["Next.js", "Clerk", "MongoDB", "Inngest", "Tailwind CSS"],
+    "image": "https://placehold.co/600x400/1A1F2C/FFFFFF?text=QuickCart+App",
+    "githubUrl": "https://github.com/",
+    "demoUrl": "https://littlewisewesbite-ten.vercel.app/"
+  },
+  {
+    "id": 3,
+    "title": "PDF-based RAG Application",
+    "description": "An intelligent document Q&A system using retrieval augmented generation techniques.",
+    "technologies": ["LangChain", "Streamlit", "FAISS", "Ollama", "Python"],
+    "image": "https://placehold.co/600x400/1A1F2C/FFFFFF?text=PDF+RAG+App",
+    "githubUrl": "https://github.com/",
+    "demoUrl": "https://drive.google.com/drive/folders/1rW2ufZNwpmeH1E4dX-JW1qkERoM-fH3P?usp=sharing"
+  },
+  {
+    "id": 4,
+    "title": "OCR & Text Analysis Tool",
+    "description": "Computer vision application that extracts and analyzes text from images and documents.",
+    "technologies": ["Google Vision API", "OpenCV", "HuggingFace", "Flask", "React"],
+    "image": "https://placehold.co/600x400/1A1F2C/FFFFFF?text=OCR+Analysis+Tool",
+    "githubUrl": "https://github.com/",
+    "demoUrl": "https://drive.google.com/file/d/1Qw308EiVN0OMuQ0q1vvTgAgCuIXhLctP/view?usp=sharing"
+  },
+  {
+    "id": 5,
+    "title": "Jobify - Job Seeking App",
+    "description": "A comprehensive platform for job seekers to find and apply for opportunities.",
+    "technologies": ["React", "MongoDB", "Express", "Node.js", "Tailwind CSS"],
+    "image": "https://placehold.co/600x400/1A1F2C/FFFFFF?text=Jobify",
+    "githubUrl": "https://github.com/",
+    "demoUrl": "https://jobify-j55w.onrender.com/dashboard/profile"
+  }
+]

--- a/src/components/ai/LivingResumeChat.tsx
+++ b/src/components/ai/LivingResumeChat.tsx
@@ -14,10 +14,44 @@ const LivingResumeChat: React.FC = () => {
   ]);
   const [input, setInput] = useState('');
   const [isSending, setIsSending] = useState(false);
+  const [utterance, setUtterance] = useState<SpeechSynthesisUtterance | null>(null);
+  const [isPaused, setIsPaused] = useState(false);
+  const [sessionId] = useState(() => {
+    if (typeof window === 'undefined') return 'default';
+    const saved = localStorage.getItem('lr-session');
+    if (saved) return saved;
+    const id = Math.random().toString(36).slice(2);
+    localStorage.setItem('lr-session', id);
+    return id;
+  });
+
+  const togglePause = () => {
+    if (typeof window === 'undefined' || !('speechSynthesis' in window)) return;
+    if (!utterance) return;
+    if (isPaused) {
+      window.speechSynthesis.resume();
+      setIsPaused(false);
+    } else {
+      window.speechSynthesis.pause();
+      setIsPaused(true);
+    }
+  };
+
+  const stopSpeech = () => {
+    if (typeof window !== 'undefined' && 'speechSynthesis' in window) {
+      window.speechSynthesis.cancel();
+      setIsPaused(false);
+      setUtterance(null);
+    }
+  };
 
   const sendMessage = async () => {
     const trimmed = input.trim();
     if (!trimmed) return;
+    if (typeof window !== 'undefined' && 'speechSynthesis' in window) {
+      window.speechSynthesis.cancel();
+      setIsPaused(false);
+    }
     const userMsg = { sender: 'user', text: trimmed } as Message;
     setMessages(prev => [...prev, userMsg]);
     setInput('');
@@ -27,12 +61,18 @@ const LivingResumeChat: React.FC = () => {
       const res = await fetch('/api/chat', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ message: trimmed, history: messages }),
+        body: JSON.stringify({ message: trimmed, sessionId, history: messages }),
       });
       const data = await res.json();
       const reply = data.reply || 'Sorry, I had trouble answering that.';
       if (typeof window !== 'undefined' && 'speechSynthesis' in window) {
-        window.speechSynthesis.speak(new SpeechSynthesisUtterance(reply));
+        const utt = new SpeechSynthesisUtterance(reply);
+        utt.onend = () => {
+          setIsPaused(false);
+          setUtterance(null);
+        };
+        setUtterance(utt);
+        window.speechSynthesis.speak(utt);
       }
       setMessages(prev => [...prev, { sender: 'bot', text: reply }]);
     } catch (err) {
@@ -78,6 +118,12 @@ const LivingResumeChat: React.FC = () => {
           />
           <Button onClick={sendMessage} disabled={isSending}>
             {isSending ? '...' : 'Send'}
+          </Button>
+          <Button type="button" onClick={togglePause} disabled={!utterance} variant="secondary">
+            {isPaused ? 'Resume Voice' : 'Pause Voice'}
+          </Button>
+          <Button type="button" onClick={stopSpeech} disabled={!utterance} variant="secondary">
+            Stop
           </Button>
         </div>
       </CardContent>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,9 @@ export default defineConfig(({ mode }) => ({
   server: {
     host: "::",
     port: 8080,
+    proxy: {
+      "/api": "http://localhost:3001",
+    },
   },
   plugins: [
     react(),


### PR DESCRIPTION
## Summary
- update README and Living Resume docs with conversation memory
- pass chat history to Llama when querying so responses keep context
- store chat history per session and send session id from the front end
- enhance chat server intent handling

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6841fd5d99ec83258b4df55728f89dad