### PR TITLE
Add Watch Me Learn timeline page

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "react-resizable-panels": "^2.1.3",
     "react-router-dom": "^6.26.2",
     "recharts": "^2.12.7",
+    "framer-motion": "^10.16.1",
     "sonner": "^1.5.0",
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
 import LivingResume from "./pages/LivingResume";
+import Timeline from "./pages/Timeline";
 
 const queryClient = new QueryClient();
 
@@ -18,6 +19,7 @@ const App = () => (
         <Routes>
           <Route path="/" element={<Index />} />
           <Route path="/living-resume" element={<LivingResume />} />
+          <Route path="/timeline" element={<Timeline />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -26,6 +26,7 @@ const Navbar = () => {
     { name: 'Achievements', href: '#achievements' },
     { name: 'Contact', href: '#contact' },
     { name: 'AI Chat', href: '/living-resume' },
+    { name: 'Watch Me Learn', href: '/timeline' },
   ];
 
   // Social links with icons

--- a/src/data/timeline.json
+++ b/src/data/timeline.json
@@ -1,0 +1,5 @@
+[
+  { "year": "2021", "prompt": "mastered the basics of HTML, CSS, and JavaScript by building a personal blog" },
+  { "year": "2022", "prompt": "learned React and deployed a portfolio site with Vercel" },
+  { "year": "2023", "prompt": "dove into AI by building a Retrieval-Augmented Generation tool with Llama and FAISS" }
+]

--- a/src/pages/Timeline.tsx
+++ b/src/pages/Timeline.tsx
@@ -1,0 +1,135 @@
+import React, { useEffect, useState, useRef } from 'react';
+import Navbar from '@/components/Navbar';
+import Footer from '@/components/Footer';
+// Load the timeline events dynamically so the list can be updated
+// without requiring a rebuild.
+import { motion } from 'framer-motion';
+
+interface RawEvent {
+  year: string;
+  prompt: string;
+}
+
+interface StoryEvent {
+  year: string;
+  story: string;
+  audioUrl?: string;
+  loading: boolean;
+}
+
+const voiceId = '21m00Tcm4TlvDq8ikWAM';
+
+const Timeline: React.FC = () => {
+  const [events, setEvents] = useState<StoryEvent[]>([]);
+  const audioRefs = useRef<Array<HTMLAudioElement | null>>([]);
+  const [playing, setPlaying] = useState<number | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      const module = await import('@/data/timeline.json');
+      const raws = module.default as RawEvent[];
+      for (const [index, ev] of raws.entries()) {
+        setEvents(prev => [...prev, { year: ev.year, story: '', loading: true }]);
+        let story = `In ${ev.year}, I ${ev.prompt}.`;
+        try {
+          const res = await fetch('/api/chat', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ message: `Write a first-person story in one or two sentences: \"In ${ev.year}, I ${ev.prompt}.\"` })
+          });
+          const data = await res.json();
+          if (data.reply) story = data.reply;
+        } catch (e) {
+          console.error('chat error', e);
+        }
+
+        let audioUrl: string | undefined;
+        try {
+          const voiceRes = await fetch(`https://api.elevenlabs.io/v1/text-to-speech/${voiceId}`, {
+            method: 'POST',
+            headers: {
+              'xi-api-key': import.meta.env.VITE_ELEVENLABS_API_KEY as string,
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({ text: story, voice_settings: { stability: 0.7, similarity_boost: 0.75 } })
+          });
+          const voiceData = await voiceRes.json();
+          audioUrl = voiceData.audio_url;
+        } catch (e) {
+          console.error('voice error', e);
+        }
+
+        audioRefs.current[index] = audioUrl ? new Audio(audioUrl) : null;
+        setEvents(prev => {
+          const copy = [...prev];
+          copy[index] = { year: ev.year, story, audioUrl, loading: false };
+          return copy;
+        });
+      }
+    };
+    load();
+    // pause audios on unmount
+    return () => {
+      audioRefs.current.forEach(a => a && a.pause());
+    };
+  }, []);
+
+  const play = (i: number) => {
+    const audio = audioRefs.current[i];
+    if (!audio) return;
+    audioRefs.current.forEach((a, idx) => {
+      if (idx !== i && a) { a.pause(); a.currentTime = 0; }
+    });
+    audio.play();
+    setPlaying(i);
+  };
+
+  const pause = (i: number) => {
+    const audio = audioRefs.current[i];
+    if (!audio) return;
+    audio.pause();
+    setPlaying(null);
+  };
+
+  return (
+    <div className="min-h-screen bg-dark text-white overflow-x-hidden">
+      <Navbar />
+      <section className="container mx-auto px-4 py-12">
+        <h1 className="text-3xl font-bold mb-12 text-center">Watch Me Learn</h1>
+        <div className="relative md:mx-20">
+          <div className="hidden md:block absolute left-1/2 top-0 bottom-0 w-px bg-white/30" />
+          {events.map((ev, i) => (
+            <motion.div
+              key={i}
+              initial={{ opacity: 0, y: 40 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true, amount: 0.4 }}
+              onViewportEnter={() => play(i)}
+              onViewportLeave={() => pause(i)}
+              className={`mb-12 md:flex md:items-start md:relative ${i % 2 === 0 ? 'md:flex-row' : 'md:flex-row-reverse'}`}
+            >
+              <span className="hidden md:block absolute left-1/2 transform -translate-x-1/2 w-4 h-4 bg-neon-purple rounded-full border-4 border-dark top-2" />
+              <div className="md:w-1/2 px-4">
+                <h3 className="text-lg font-semibold">{ev.year}</h3>
+                <p className="mt-2 min-h-[3rem]">
+                  {ev.loading ? <span className="inline-block animate-spin border-b-2 border-white rounded-full w-4 h-4" /> : ev.story}
+                </p>
+                {ev.audioUrl && !ev.loading && (
+                  <button
+                    className="mt-2 text-sm underline"
+                    onClick={() => (playing === i ? pause(i) : play(i))}
+                  >
+                    {playing === i ? 'Pause' : 'Play'}
+                  </button>
+                )}
+              </div>
+            </motion.div>
+          ))}
+        </div>
+      </section>
+      <Footer />
+    </div>
+  );
+};
+
+export default Timeline;


### PR DESCRIPTION
## Summary
- add framer motion dependency
- create timeline JSON dataset
- implement Timeline page with AI story and audio
- wire up /timeline route
- expose new "Watch Me Learn" link in Navbar
- load timeline dynamically and pause audio when not visible

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6844b351350c8325a0f02ed10c5437c3