### PR TITLE
Improve speech input with Whisper backend

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ flask
 requests
 flask-cors
 TTS
+openai-whisper

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -3,3 +3,4 @@ requests
 sentence-transformers
 scikit-learn
 numpy
+openai-whisper


### PR DESCRIPTION
## Summary
- add Whisper as server-side STT engine
- expose `/api/speech` endpoint for audio transcription
- send microphone audio to `/api/speech` from `LivingResumeChat`
- update Python requirements with `openai-whisper`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `python -m py_compile server/app.py`
- `npm run build --silent` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d59202c5483259ca4891beeba3607